### PR TITLE
`package.json` should point to main script.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "angular-busy",
+  "main": "angular-busy.js",
   "version": "4.1.2",
   "description": "",
   "repository": {


### PR DESCRIPTION
Without this entry in `package.json`, I am unable to require this as a module using something such as `browserify`.